### PR TITLE
TCO-286: Update Cards responsive sizing

### DIFF
--- a/src/components/Buttons/Buttons.stories.js
+++ b/src/components/Buttons/Buttons.stories.js
@@ -141,9 +141,9 @@ export const All = () => {
       Object.keys(sizes)
         .map(sizeKey =>
           itemWrapper(`
-            <button type="button" class="tco-btn tco-btn--icon ${styles[styleKey]} ${
-            sizes[sizeKey]
-          }">
+            <button type="button" class="tco-btn tco-btn--icon ${
+              styles[styleKey]
+            } ${sizes[sizeKey]}">
               <svg class="icon" width="16" height="16" viewBox="0 0 16 16">
                 <use xlink:href="/img/svg-sprite.svg#${iconId}"></use>
               </svg>

--- a/src/components/Card/Card.stories.js
+++ b/src/components/Card/Card.stories.js
@@ -53,6 +53,7 @@ export const personCard = () => {
   );
 
   return `
+  <div class="documentation-grid-container">
   <div class="tco-card tco-card--person" style="background-image: url(${image})">
     <a href="#" class="tco-card-link">
       <div class="tco-card-content-container">
@@ -60,6 +61,15 @@ export const personCard = () => {
         <p class="tco-card-content-description">${title}</p>
       </div>
     </a>
+  </div>
+  <div class="tco-card tco-card--person" style="background-image: url(${image})">
+  <a href="#" class="tco-card-link">
+    <div class="tco-card-content-container">
+      <h3 class="tco-card-content-heading">${name}</h3>
+      <p class="tco-card-content-description">${title}</p>
+    </div>
+  </a>
+  </div>
   </div>`;
 };
 

--- a/src/components/Card/_card.scss
+++ b/src/components/Card/_card.scss
@@ -13,10 +13,9 @@
   }
 
   &-content-heading {
-    @include type-display-medium;
     @include type-link;
+    @include type-display-medium($color-tint-blue-primary);
     display: inline;
-    line-height: 1.2;
   }
 
   &-content-description {
@@ -41,10 +40,13 @@
   &--cta-small {
     @include spacing-inset-16;
     @include card-scale;
-    width: 215px;
     background-position: 50%;
     background-repeat: no-repeat;
     background-size: cover;
+
+    @include wider-than($breakpoint-tablet-portrait) {
+      width: 215px;
+    }
 
     > .tco-card-link {
       display: flex;

--- a/src/primitives/_documentation-styles/Grid.scss
+++ b/src/primitives/_documentation-styles/Grid.scss
@@ -38,3 +38,9 @@
     width: 100%;
   }
 }
+
+.documentation-grid-container {
+  display: grid;
+  grid-gap: 1em;
+  grid-template-columns: repeat(auto-fit, minmax(158px, 1fr));
+}

--- a/src/styles/settings/mixins/_cards.scss
+++ b/src/styles/settings/mixins/_cards.scss
@@ -1,5 +1,5 @@
 @mixin card-base {
-  min-width: 222px;
+  min-width: 158px;
   min-height: 300px;
   border-radius: $border-radius-medium;
   background: $color-background-primary;


### PR DESCRIPTION
### Feature Status
- [x]  Complete, ready for QA
- [ ]  In Progress

### Description of Changes
Updated responsive sizing of cards. Added a documentation-only grid class to perform the 2-up.
Ironically, the `.documentation-grid` class is using `display: flex` and not `display: grid`. 🤷‍♂️ 

- [TCO-286]
- [Abstract collection](https://app.abstract.com/projects/f34f0fd0-41e2-11e9-bbd9-65ff88972988/branches/master/commits/latest/files/f05c1e58-2037-4795-92de-b98a53bff907/layers/9E7EB6AE-A9A1-4B4A-81B0-6961A8C25DEA?collectionId=401ff3ce-20f3-4066-b8a4-524e5f91c8a3&collectionLayerId=a3b9c074-650e-4d02-b813-d4e665196e62&mode=build&selected=3355958079-5FAB22CC-2E3A-48CB-A7E7-AAD23926EF6B)

#### Screenshots
![Cards mobile](https://user-images.githubusercontent.com/12416380/89685226-ee85e580-d8c9-11ea-8b67-62f4a833301a.png)


### How to Review

1. Click the deploy preview link OR `git checkout && git fetch fix/TCO-286-cards-mobile`
2. Navigate to **Components** > **Card** > **Person Card**

### Merge Checklist:
- [x] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the documentation.
- [x] I have verified that no browser console errors are attributed to my changes
- [x] I have removed any commented out code.
- [x] I have run `npm run format` and `npm run lint` and both run without errors or warnings.
- [x] npm run build runs without failure.

### GIF Description

![Have a great weekend](https://media.giphy.com/media/hte3U58BWwIhyU7UZz/giphy.gif)


[TCO-286]: https://thinkbrownstone.atlassian.net/browse/TCO-286