### PR TITLE
TCO-299: Create Post Card

### DIFF
--- a/src/components/Card/Card.stories.js
+++ b/src/components/Card/Card.stories.js
@@ -1,6 +1,6 @@
 import { select, text } from '@storybook/addon-knobs';
 
-const sizes = ['large', 'medium', 'small'];
+const sizes = ['xlarge', 'large', 'medium', 'small'];
 
 export const summaryCard = () => {
   const heading = text('Heading', 'Full Experience & Service Design');
@@ -104,7 +104,7 @@ export const postCard = () => {
   const date = text('Post date', 'May 21, 2020');
 
   return `
-  <div class="tco-card tco-card--post tco-card--post-${size}">
+  <div class="tco-card tco-card--post tco-card--post--${size}">
     <a href="#" class="tco-card-link">
       <div class="tco-card-image-container">
         <img class="tco-card-image" alt="Card image" src="${image}" />

--- a/src/components/Card/_card.scss
+++ b/src/components/Card/_card.scss
@@ -149,7 +149,7 @@
   }
 }
 
-.tco-card--post-small {
+.tco-card--post--small {
   @include wider-than($breakpoint-tablet-portrait) {
     max-width: 280px;
   }
@@ -167,14 +167,30 @@
   }
 }
 
-.tco-card--post-medium {
+.tco-card--post--medium {
   @include wider-than($breakpoint-tablet-portrait) {
     max-width: 380px;
   }
 }
 
-.tco-card--post-large {
+.tco-card--post--large {
   @include wider-than($breakpoint-tablet-portrait) {
     max-width: 480px;
+  }
+}
+
+.tco-card--post--xlarge {
+  @include wider-than($breakpoint-tablet-portrait) {
+    max-width: 880px;
+    min-height: 0;
+
+    > .tco-card-link {
+      display: flex;
+    }
+
+    .tco-card-image-container,
+    .tco-card-content-container {
+      flex-basis: 50%;
+    }
   }
 }


### PR DESCRIPTION
### Feature Status
- [x]  Complete, ready for QA
- [ ]  In Progress

### Description of Changes
Created Post Card variant of the Card component.

- [TCO-299]
- [Abstract collection](https://app.abstract.com/projects/f34f0fd0-41e2-11e9-bbd9-65ff88972988/branches/master/collections/401ff3ce-20f3-4066-b8a4-524e5f91c8a3)

#### Screenshots
It supports four different sizes: `small`, `medium`, `large`, `xlarge`:

![Card sizes](https://user-images.githubusercontent.com/12416380/89939178-94489580-dbe5-11ea-8d51-f9fb1ca18704.png)

![XL size](https://user-images.githubusercontent.com/12416380/89949873-8e0ee500-dbf6-11ea-8bdd-e813fbfd099d.png)


I wasn't sure about our BEM-link CSS convention since `--post` is already a modifier of the base `tco-card` class so I have:
- `.tco-card--post tco-card--post-small`
- `.tco-card--post tco-card--post-medium`
- `.tco-card--post tco-card--post-large`

Not sure if there should be an extra double-dash there.

### How to Review
1. Click on the Netlify deploy preview link below OR
2. `git fetch && git checkout feature/TCO-299-blog-post-card`
3. Navigate to **Components** > **Card** > **Post Card**
4. Adjust the knobs to see the variations

### Merge Checklist:
- [x] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the documentation.
- [x] I have verified that no browser console errors are attributed to my changes
- [x] I have removed any commented out code.
- [x] I have run `npm run format` and `npm run lint` and both run without errors or warnings.
- [x] npm run build runs without failure.

### GIF Description
![Shark Week ooh ha ha](https://media.giphy.com/media/11YgA8k2tuNjz2/giphy.gif)


[TCO-299]: https://thinkbrownstone.atlassian.net/browse/TCO-299