### PR TITLE
TCO-287: Create Card Grid component

### DIFF
--- a/src/components/Card/_card.scss
+++ b/src/components/Card/_card.scss
@@ -5,6 +5,7 @@
   @include card-container-shadow;
   @include spacing-inset-32;
   max-width: 380px;
+  overflow: hidden;
 
   &-link {
     @include type-not-link;

--- a/src/components/CardGrid/CardGrid.stories.js
+++ b/src/components/CardGrid/CardGrid.stories.js
@@ -1,0 +1,125 @@
+import { number } from '@storybook/addon-knobs';
+
+const summaryCard = () => {
+  const heading = 'Full Experience & Service Design';
+  const summary =
+    'The best experiences are consistent across all channels, so we always consider the entire ecosystem your users interact within—designing for people wherever they click, tap, talk, touch, work, or play.';
+  const image =
+    'https://3vwizk2qtr8l3diwrm3r2ba0-wpengine.netdna-ssl.com/wp-content/themes/tbiv3/img/svgs/services-full-experience-service.svg';
+
+  return `
+  <div class="tco-card tco-card--summary">
+    <a href="#" class="tco-card-link">
+      <div class="tco-card-image-container">
+        <img class="tco-card-image" alt="An adorable kitten" src="${image}" />
+      </div>
+      <div class="tco-card-content-container">
+        <h3 class="tco-card-content-heading">${heading}</h3>
+        <p class="tco-card-content-description">${summary}</p>
+      </div>
+    </a>
+  </div>`;
+};
+
+const postCard = size => {
+  const image =
+    'https://thinkstaging.wpengine.com/wp-content/uploads/2015/12/ss-internetprovider-mobile-top.jpg';
+  const eyebrow = 'Case Study';
+  const heading = 'Mobile Product Strategy';
+  const description =
+    'We helped one of the world’s largest media companies design and launch a new product and service line.';
+
+  return `
+  <div class="tco-card tco-card--post tco-card--post--${size}">
+    <a href="#" class="tco-card-link">
+      <div class="tco-card-image-container">
+        <img class="tco-card-image" alt="Card image" src="${image}" />
+      </div>
+      <div class="tco-card-content-container">
+        ${
+          eyebrow
+            ? '<span class="tco-card-content-eyebrow">' + eyebrow + '</span>'
+            : ''
+        }
+        <h3 class="tco-card-content-heading">${heading}</h3>
+        <p class="tco-card-content-description">${description}</p>
+      </div>
+    </a>
+  </div>`;
+};
+
+const personCard = () => {
+  const name = 'Abby DePrimo';
+  const title = 'Vice President, Design Operations';
+  const image =
+    'https://3vwizk2qtr8l3diwrm3r2ba0-wpengine.netdna-ssl.com/wp-content/uploads/2020/03/AbbyDePrimo_Web.jpg';
+
+  return `
+  <div class="tco-card tco-card--person" style="background-image: url(${image})">
+    <a href="#" class="tco-card-link">
+      <div class="tco-card-content-container">
+        <h3 class="tco-card-content-heading">${name}</h3>
+        <p class="tco-card-content-description">${title}</p>
+      </div>
+    </a>
+  </div>`;
+};
+
+export const oneColumn = () => {
+  const columns = number('Column count', 1);
+
+  return `
+  <div class="tco-card-grid tco-card-grid--${columns}-column">
+    ${postCard('xlarge')}
+  </div>`;
+};
+
+export const twoColumn = () => {
+  const columns = number('Column count', 2);
+
+  return `
+  <div class="tco-card-grid tco-card-grid--${columns}-column">
+    ${postCard()}
+    ${postCard()}
+  </div>`;
+};
+
+export const threeColumn = () => {
+  const columns = number('Column count', 3);
+
+  return `
+  <div class="tco-card-grid tco-card-grid--${columns}-column">
+    ${summaryCard()}
+    ${summaryCard()}
+    ${summaryCard()}
+  </div>`;
+};
+
+export const fourColumn = () => {
+  const columns = number('Column count', 4);
+
+  return `
+  <div class="tco-card-grid tco-card-grid--${columns}-column">
+    ${postCard('small')}
+    ${postCard('small')}
+    ${postCard('small')}
+    ${postCard('small')}
+  </div>`;
+};
+
+export const fiveColumn = () => {
+  const columns = number('Column count', 5);
+
+  return `
+  <div class="tco-card-grid tco-card-grid--${columns}-column">
+    ${personCard()}
+    ${personCard()}
+    ${personCard()}
+    ${personCard()}
+    ${personCard()}
+  </div>`;
+};
+
+export default {
+  title: 'Components / Card Grid'
+};

--- a/src/components/CardGrid/_card-grid.scss
+++ b/src/components/CardGrid/_card-grid.scss
@@ -1,0 +1,32 @@
+.tco-card-grid {
+  display: grid;
+  grid-gap: 20px;
+  align-items: flex-start;
+  justify-content: center;
+
+  &--2-column {
+    @include wider-than($breakpoint-tablet-portrait) {
+      grid-template-columns: repeat(2, auto);
+    }
+  }
+
+  &--3-column {
+    @include wider-than($breakpoint-tablet-portrait) {
+      grid-template-columns: repeat(3, auto);
+    }
+  }
+
+  &--4-column {
+    @include wider-than($breakpoint-tablet-portrait) {
+      grid-template-columns: repeat(4, auto);
+    }
+  }
+
+  &--5-column {
+    grid-template-columns: repeat(2, auto);
+
+    @include wider-than($breakpoint-tablet-portrait) {
+      grid-template-columns: repeat(5, auto);
+    }
+  }
+}

--- a/src/components/_index.scss
+++ b/src/components/_index.scss
@@ -1,5 +1,6 @@
 @import 'Buttons/buttons';
 @import 'Card/card';
+@import 'CardGrid/card-grid';
 @import 'Forms/forms';
 @import 'Navigation/navigation';
 @import 'Header/header';


### PR DESCRIPTION
### Feature Status
- [x]  Complete, ready for QA
- [ ]  In Progress

### Description of Changes
Create Card Grid component. Supports 1-5 columns.

- [TCO-287]
- [Abstract collection](https://app.abstract.com/projects/f34f0fd0-41e2-11e9-bbd9-65ff88972988/branches/master/collections/8839f30a-77db-46b1-8139-d381ce3f759b)

### Screenshots
![Card grid](https://user-images.githubusercontent.com/12416380/90046786-eac5da80-dc9e-11ea-9b21-17c9e6caf778.png)

### How to Review
1. Click on the Netlify deploy preview link below OR
2. `git fetch && git checkout feature/TCO-287-card-grid` then `npm start`
3. Navigate to **Components** > **Card Grid**
4. View the different variations (can also update the column count with the knob)

**DEVELOPER NOTE**: This does not work in IE11. We need a ticket to add Autoprefixer to the build.

### Merge Checklist:
- [x] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the documentation.
- [x] I have verified that no browser console errors are attributed to my changes
- [x] I have removed any commented out code.
- [x] I have run `npm run format` and `npm run lint` and both run without errors or warnings.
- [x] npm run build runs without failure.

### GIF Description
![Jenga sorcery](https://i.gifer.com/origin/92/929f97d39f5afb05308b982439adcb51_w200.gif)


[TCO-287]: https://thinkbrownstone.atlassian.net/browse/TCO-287