### PR TITLE
A11 y/tcr 47 50

### DIFF
--- a/src/components/Forms/_forms.scss
+++ b/src/components/Forms/_forms.scss
@@ -346,25 +346,17 @@ $opacity--disabled: 0.4;
 
 .tco-form-toggle {
   @extend %tco-accessibly-hidden;
-
-  &:focus + label::before {
-    outline: 2px solid $color-tint-blue-primary;
-  }
+  @extend %tco-form-input--pseudo;
 
   + label {
-    position: relative;
-    margin-right: $spacing-inline-32;
     padding-left: rem(48px);
-    font-weight: 400;
-    font-size: $font-size-14;
+    line-height: 1.7;
 
     &::before {
-      content: '';
-      position: absolute;
       top: rem(2px);
-      left: 0;
       width: rem(36px);
       height: rem(20px);
+      border-width: 0;
       border-radius: rem(100px);
       background-color: $color-foreground-tertiary;
     }


### PR DESCRIPTION
### Feature Status
- [x]  Complete, ready for QA
- [ ]  In Progress

### Description of Changes
Added focus state to pseudo element inputs, increase color contrast for checkbox. I also matched up the label styles for checkboxes and radio buttons

https://thinkbrownstone.atlassian.net/browse/TCR-50
https://thinkbrownstone.atlassian.net/browse/TCR-49
https://thinkbrownstone.atlassian.net/browse/TCR-48
https://thinkbrownstone.atlassian.net/browse/TCR-47

#### Screenshots
<img width="358" alt="Screen Shot 2021-01-14 at 2 07 28 PM" src="https://user-images.githubusercontent.com/1825366/104638105-ba320480-5673-11eb-88b9-7b213fed16af.png">
<img width="350" alt="Screen Shot 2021-01-14 at 2 08 22 PM" src="https://user-images.githubusercontent.com/1825366/104638106-baca9b00-5673-11eb-83c9-d37554942cb8.png">
<img width="195" alt="Screen Shot 2021-01-14 at 2 29 58 PM" src="https://user-images.githubusercontent.com/1825366/104639172-18131c00-5675-11eb-969f-ff53a3723b53.png">


### Merge Checklist:
- [ ] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the documentation.
- [ ] I  have verified that no browser console errors are attributed to my changes
- [ ] I have removed any commented out code.
- [ ] I have run `npm run format` and `npm run lint` and both run without errors or warnings.
- [x] npm run build runs without failure.

### GIF Description
Share a fun gif that describes this PR & how it makes you feel.

![Welcome](https://media.giphy.com/media/OkJat1YNdoD3W/giphy.gif)
