### PR TITLE
open submenu on focus

### DIFF
--- a/src/components/Navigation/_navigation.scss
+++ b/src/components/Navigation/_navigation.scss
@@ -203,33 +203,6 @@
   }
 }
 
-.tco-menu-site-nav-submenu {
-  @include list-plain;
-
-  @include wider-than($breakpoint-xl) {
-    .menu-item-has-children:hover &,
-    .menu-item-has-children:focus & {
-      // Wordpress automated class
-      position: absolute;
-      top: 100%; // height of arrow on submenu
-      left: 50%;
-      min-width: 250px;
-      margin-left: -125px;
-      padding: 0 $spacing-inline-12;
-      border-bottom-right-radius: 4px;
-      border-bottom-left-radius: 4px;
-      background-color: $color-background-primary;
-      box-shadow: inset 0 5px 10px 0 rgba(75, 75, 75, 0.05);
-    }
-  }
-  display: none;
-
-  .menu-item-has-children:hover &,
-  .menu-item-has-children:focus & {
-    display: block;
-  }
-}
-
 .tco-menu-site-nav-submenu-link {
   margin: 0;
   padding: $spacing-stack-16 $spacing-stack-8;
@@ -237,5 +210,32 @@
 
   .tco-menu-site-nav-submenu-item:last-of-type & {
     border-bottom: 0;
+  }
+}
+
+.tco-menu-site-nav-submenu {
+  @include list-plain;
+  display: none;
+}
+
+.menu-item-has-children > a {
+  @include wider-than($breakpoint-xl) {
+    &:hover,
+    &:focus {
+      + .tco-menu-site-nav-submenu {
+        position: absolute;
+        top: 100%; // height of arrow on submenu
+        left: 50%;
+        // Wordpress automated class
+        display: block;
+        min-width: 250px;
+        margin-left: -125px;
+        padding: 0 $spacing-inline-12;
+        border-bottom-right-radius: 4px;
+        border-bottom-left-radius: 4px;
+        background-color: $color-background-primary;
+        box-shadow: inset 0 5px 10px 0 rgba(75, 75, 75, 0.05);
+      }
+    }
   }
 }


### PR DESCRIPTION
### Feature Status
- [x]  Complete, ready for QA
- [ ]  In Progress

### Description of Changes
Open navigation submenu on focus. Note- when tabbing through the navigation in the UI library, an nav item with `.menu-item-has-children` will not gain focus. However, in the theme this works as expected

https://thinkcompany.atlassian.net/browse/TCR-51

#### Screenshots
<img width="1034" alt="Screen Shot 2021-01-19 at 10 31 24 AM" src="https://user-images.githubusercontent.com/1825366/105056772-93444b80-5a42-11eb-92b8-064c92e3cf64.png">


### How to Review
Manually set focus on `.menu-item-has-children > .tco-menu-site-nav-link` in dev tools.


### Merge Checklist:
- [ ] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the documentation.
- [ ] I  have verified that no browser console errors are attributed to my changes
- [ ] I have removed any commented out code.
- [ ] I have run `npm run format` and `npm run lint` and both run without errors or warnings.
- [ ] npm run build runs without failure.

### GIF Description
Share a fun gif that describes this PR & how it makes you feel.

![Welcome](https://media.giphy.com/media/OkJat1YNdoD3W/giphy.gif)
