### PR TITLE
TCR-63: remove unused bg color options

### DIFF
--- a/src/components/Teaser/teaser.stories.js
+++ b/src/components/Teaser/teaser.stories.js
@@ -2,9 +2,6 @@ import { select, boolean, text, number } from '@storybook/addon-knobs';
 
 const colors = {
   Default: '',
-  Tan: 'tco-container-wrapper--tan',
-  Blue: 'tco-container-wrapper--blue',
-  Navy: 'tco-container-wrapper--navy',
   Glass: 'tco-container-wrapper--glass'
 };
 

--- a/src/components/TextMedia/text-media.stories.js
+++ b/src/components/TextMedia/text-media.stories.js
@@ -4,9 +4,6 @@ import { imageOnly } from '../ImageOnly/image-only.stories';
 
 const colors = {
   Default: '',
-  Tan: 'tco-container-wrapper--tan',
-  Blue: 'tco-container-wrapper--blue',
-  Navy: 'tco-container-wrapper--navy',
   Glass: 'tco-container-wrapper--glass'
 };
 const alignments = ['center', 'left', 'right'];

--- a/src/components/TextOnly/text-only.stories.js
+++ b/src/components/TextOnly/text-only.stories.js
@@ -2,9 +2,6 @@ import { select, text, boolean } from '@storybook/addon-knobs';
 
 const colors = {
   Default: '',
-  Tan: 'tco-container-wrapper--tan',
-  Blue: 'tco-container-wrapper--blue',
-  Navy: 'tco-container-wrapper--navy',
   Glass: 'tco-container-wrapper--glass'
 };
 const alignments = ['center', 'left', 'right'];


### PR DESCRIPTION
### Feature Status
- [x]  Complete, ready for QA
- [ ]  In Progress

### Description of Changes
Remove unused bg color options from several components

https://thinkcompany.atlassian.net/browse/TCR-63

#### Screenshots
<img width="534" alt="Screen Shot 2021-02-01 at 3 36 17 PM" src="https://user-images.githubusercontent.com/1825366/106515195-509f5c00-64a3-11eb-9522-4b63ea98c9cd.png">


### How to Review
git fetch && git checkout feature/TCR-63-bg-color
Navigate to Components > Text Media or Text Only or Teaser

### Merge Checklist:
- [x] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the documentation.
- [x] I  have verified that no browser console errors are attributed to my changes
- [x] I have removed any commented out code.
- [x] I have run `npm run format` and `npm run lint` and both run without errors or warnings.
- [x] npm run build runs without failure.

### GIF Description
Share a fun gif that describes this PR & how it makes you feel.

![Welcome](https://media.giphy.com/media/OkJat1YNdoD3W/giphy.gif)
