### PR TITLE
TCR-93: fix ie bug

### DIFF
--- a/src/components/TextOnly/_text-only.scss
+++ b/src/components/TextOnly/_text-only.scss
@@ -1,8 +1,6 @@
 $bubble-max: 600px;
 
 .tco-text-only {
-  width: 100%;
-
   &--right,
   &--center {
     display: flex;
@@ -17,6 +15,10 @@ $bubble-max: 600px;
   &--center {
     align-items: center;
     text-align: center;
+  }
+
+  &-content {
+    width: 100%;
   }
 
   &-cta {


### PR DESCRIPTION
### Feature Status
- [x]  Complete, ready for QA
- [ ]  In Progress

### Description of Changes
Content overflowed it's container when `align-items: center` set on container. 

https://thinkcompany.atlassian.net/browse/TCR-93

#### Screenshots
<img width="1408" alt="Screen Shot 2021-02-02 at 7 20 28 AM" src="https://user-images.githubusercontent.com/1825366/106599970-ca792900-6527-11eb-8867-07abc70c3c9a.png">

### How to Review
git fetch && git checkout bug/TCR-93-text-only-ie
npm start
Go to Browserstack > IE 11 Win 10
Navigate to Components > Text Only
Select text alignment center

### Merge Checklist:
- [ ] My code follows the style guidelines of this project.
- [x] I have made corresponding changes to the documentation.
- [x] I  have verified that no browser console errors are attributed to my changes
- [x] I have removed any commented out code.
- [x] I have run `npm run format` and `npm run lint` and both run without errors or warnings.
- [x] npm run build runs without failure.

### GIF Description
Share a fun gif that describes this PR & how it makes you feel.

![Welcome](https://media.giphy.com/media/OkJat1YNdoD3W/giphy.gif)
