### PR TITLE
TCR-160: fix image stretch in safari

### DIFF
--- a/src/components/Author/author.scss
+++ b/src/components/Author/author.scss
@@ -14,6 +14,7 @@ $author-image-max: 480px;
 
   .tco-text-media-content {
     &-media {
+      align-items: flex-start;
       max-width: $author-image-max;
     }
   }


### PR DESCRIPTION
### Feature Status
- [x]  Complete, ready for QA
- [ ]  In Progress

### Description of Changes
Safari stretched image container

[[TCR-160](https://thinkcompany.atlassian.net/browse/TCR-160)]

#### Screenshots
Include any screenshots if they are relevant.


### How to Review
Outline the steps a reviewer should take to view & test code locally.

1. `git fetch && git checkout bug/TCR-160-author-img`
2. `npm start`
3. Navigate to **Components** > **Author**

### Merge Checklist:
- [x] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the documentation.
- [x] I have verified that no browser console errors are attributed to my changes
- [x] I have removed any commented out code.
- [x] I have run `npm run format` and `npm run lint` and both run without errors or warnings.
- [x] `npm run build` runs without failure.

### GIF Description
Share a fun gif that describes this PR & how it makes you feel.

![IE](https://media.giphy.com/media/Z3Av47b2Xrwru/giphy.gif)
