### PR TITLE
TCR-158: content item visual bugs

### DIFF
--- a/src/components/ContentItem/ContentItem.stories.js
+++ b/src/components/ContentItem/ContentItem.stories.js
@@ -1,10 +1,9 @@
 import { select, text } from '@storybook/addon-knobs';
 
-const alignments = ['center', 'left', 'right'];
+const alignments = ['left', 'right'];
 
 export const Default = () => {
   const alignment = select('Media Alignment', alignments, 'right');
-  const textAlignment = select('Text Alignment', alignments, 'left');
   const tag = text('Tag', 'Workshop');
   const date = text('Date', 'June 2, 2020');
   const location = text('Location', 'Malvern, PA');
@@ -25,7 +24,7 @@ export const Default = () => {
     <div class="tco-container-wrapper">
       <div class="tco-container tco-container--default">
         <article class="tco-content-item tco-text-media tco-text-media--align-${alignment} tco-content-item--align-${alignment}">
-          <div class="tco-text-media-content tco-text-media-content-text tco-text-media-content-text--${textAlignment}">
+          <div class="tco-text-media-content tco-text-media-content-text">
             <div class="tco-content-item-meta">
               ${
                 tag

--- a/src/components/ContentItem/_content-item.scss
+++ b/src/components/ContentItem/_content-item.scss
@@ -21,10 +21,17 @@ $bullet-offset: 15px;
     display: flex;
     flex-flow: row wrap;
     align-items: center;
-    margin-bottom: $spacing-stack-12;
 
     @include wider-than($breakpoint-tablet-portrait) {
       margin-bottom: $spacing-stack-20;
+    }
+
+    span {
+      margin-bottom: $spacing-stack-12;
+
+      @include wider-than($breakpoint-tablet-portrait) {
+        margin-bottom: 0;
+      }
     }
   }
 
@@ -64,7 +71,7 @@ $bullet-offset: 15px;
   }
 
   .tco-link {
-    @include type-not-link;
+    @include type-link($show-initial: false);
   }
 
   .tco-text-media-lede {


### PR DESCRIPTION
### Feature Status
- [x]  Complete, ready for QA
- [ ]  In Progress

### Description of Changes
- Headline underline on hover
- meta data spacing on mobile
- remove alignment options

[TCR-158]

#### Screenshots
<img width="552" alt="Screen Shot 2021-02-28 at 7 50 03 AM" src="https://user-images.githubusercontent.com/1825366/109419093-a7f8f500-7999-11eb-8f1e-a2a41544a930.png">
<img width="295" alt="Screen Shot 2021-02-28 at 7 50 21 AM" src="https://user-images.githubusercontent.com/1825366/109419094-a7f8f500-7999-11eb-8684-1807fdc9db3c.png">

### How to Review
Outline the steps a reviewer should take to view & test code locally.

1. `git fetch && git checkout bug/TCR-158-content-item`
2. `npm start`
3. Navigate to **Components** > **Content Item**

### Merge Checklist:
- [x] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the documentation.
- [x] I have verified that no browser console errors are attributed to my changes
- [x] I have removed any commented out code.
- [x] I have run `npm run format` and `npm run lint` and both run without errors or warnings.
- [x] `npm run build` runs without failure.

### GIF Description
Share a fun gif that describes this PR & how it makes you feel.

![Welcome](https://media.giphy.com/media/OkJat1YNdoD3W/giphy.gif)


[TCR-158]: https://thinkcompany.atlassian.net/browse/TCR-158