### PR TITLE
TCR-279: Button focus styles

### DIFF
--- a/src/components/Buttons/_buttons.scss
+++ b/src/components/Buttons/_buttons.scss
@@ -26,8 +26,15 @@ $color-hover: #08519a;
   }
 
   &:focus {
-    border-color: $color-classic-navy;
-    outline: none;
+    box-shadow: 0 0 20px 0 rgba($color-hover, 0.5);
+    outline: 2px solid $color-hover;
+    outline-offset: 2px;
+  }
+
+  &:active,
+  &:focus {
+    border-color: $color-hover;
+    background-color: $color-hover;
   }
 
   &[disabled],
@@ -45,11 +52,6 @@ $color-hover: #08519a;
   border: 1px solid $color-classic-blue;
   background: $color-classic-blue;
   color: $color-foreground-on-tint;
-
-  &:active,
-  &:focus {
-    border-color: $color-classic-navy;
-  }
 
   &[disabled],
   &:disabled {
@@ -70,6 +72,10 @@ $color-hover: #08519a;
 
   &:active {
     border-color: $color-hover;
+  }
+
+  &:focus {
+    color: $color-foreground-on-tint;
   }
 
   &[disabled],


### PR DESCRIPTION
### Feature Status
- [x]  Complete, ready for QA
- [ ]  In Progress

### Description of Changes
Per Alex, `<button>`s need a more obvious focus state. 
I haven't been able to track down the abstract file with the exact styles, so I had to guess what the "soft glow" translates to, but I think I came close.

[TCR-279]


#### Screenshots
![Screen Shot 2021-07-09 at 4 36 26 PM](https://user-images.githubusercontent.com/1825366/125133948-94426580-e0d4-11eb-80e4-e4d71002d97c.png)
![Screen Shot 2021-07-09 at 4 36 48 PM](https://user-images.githubusercontent.com/1825366/125133950-94426580-e0d4-11eb-98d2-34272284638d.png)



### How to Review
Outline the steps a reviewer should take to view & test code locally.

1. `git fetch && git checkout <your-branch>`
2. `npm start`
3. Navigate to **Components** > **Your Component**

### Dependencies
List all NPM dependencies added or changed and explain why they were added.
If no dependencies were added or changed, this heading can be removed


### Merge Checklist:
- [ ] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have verified that no browser console errors are attributed to my changes
- [ ] I have removed any commented out code.
- [ ] I have run `npm run format` and `npm run lint` and both run without errors or warnings.
- [ ] `npm run build` runs without failure.

### GIF Description
Share a fun gif that describes this PR & how it makes you feel.

![Welcome](https://media.giphy.com/media/OkJat1YNdoD3W/giphy.gif)


[TCR-279]: https://thinkcompany.atlassian.net/browse/TCR-279