### PR TITLE
Update postcss config

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -12,6 +12,7 @@ module.exports = {
         actions: false
       }
     },
+    '@storybook/addon-postcss',
     '@stormid/storybook-html-addon-markup'
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@thinkcompany/think-ui-library",
-      "version": "1.3.4",
+      "version": "1.3.7",
       "dependencies": {
         "@mdx-js/react": "^1.6.22",
         "css-loader": "^3.6.0",
@@ -27,6 +27,7 @@
         "@storybook/addon-controls": "^6.3.7",
         "@storybook/addon-docs": "6.3.7",
         "@storybook/addon-essentials": "^6.3.7",
+        "@storybook/addon-postcss": "^2.0.0",
         "@storybook/addon-viewport": "^6.3.7",
         "@storybook/html": "^6.3.7",
         "autoprefixer": "^9.8.6",
@@ -5173,6 +5174,94 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-postcss": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-postcss/-/addon-postcss-2.0.0.tgz",
+      "integrity": "sha512-Nt82A7e9zJH4+A+VzLKKswUfru+T6FJTakj4dccP0i8DSn7a0CkzRPrLuZBq8tg4voV6gD74bcDf3gViCVBGtA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/node-logger": "^6.1.14",
+        "css-loader": "^3.6.0",
+        "postcss": "^7.0.35",
+        "postcss-loader": "^4.2.0",
+        "style-loader": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "yarn": "^1.17.0"
+      }
+    },
+    "node_modules/@storybook/addon-postcss/node_modules/loader-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+      "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+      "dev": true,
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/@storybook/addon-postcss/node_modules/postcss-loader": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-4.3.0.tgz",
+      "integrity": "sha512-M/dSoIiNDOo8Rk0mUqoj4kpGq91gcxCfb9PoyZVdZ76/AuhxylHDYZblNE8o+EQ9AMSASeMFEKxZf5aU6wlx1Q==",
+      "dev": true,
+      "dependencies": {
+        "cosmiconfig": "^7.0.0",
+        "klona": "^2.0.4",
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0",
+        "semver": "^7.3.4"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "postcss": "^7.0.0 || ^8.0.1",
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-postcss/node_modules/schema-utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@storybook/addon-postcss/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@storybook/addon-viewport": {
@@ -29051,6 +29140,65 @@
             "@storybook/components": "^6.3.0",
             "@storybook/core-events": "^6.3.0",
             "ts-dedent": "^2.1.1"
+          }
+        }
+      }
+    },
+    "@storybook/addon-postcss": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-postcss/-/addon-postcss-2.0.0.tgz",
+      "integrity": "sha512-Nt82A7e9zJH4+A+VzLKKswUfru+T6FJTakj4dccP0i8DSn7a0CkzRPrLuZBq8tg4voV6gD74bcDf3gViCVBGtA==",
+      "dev": true,
+      "requires": {
+        "@storybook/node-logger": "^6.1.14",
+        "css-loader": "^3.6.0",
+        "postcss": "^7.0.35",
+        "postcss-loader": "^4.2.0",
+        "style-loader": "^1.3.0"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "postcss-loader": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-4.3.0.tgz",
+          "integrity": "sha512-M/dSoIiNDOo8Rk0mUqoj4kpGq91gcxCfb9PoyZVdZ76/AuhxylHDYZblNE8o+EQ9AMSASeMFEKxZf5aU6wlx1Q==",
+          "dev": true,
+          "requires": {
+            "cosmiconfig": "^7.0.0",
+            "klona": "^2.0.4",
+            "loader-utils": "^2.0.0",
+            "schema-utils": "^3.0.0",
+            "semver": "^7.3.4"
+          }
+        },
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@storybook/addon-docs": "6.3.7",
     "@storybook/addon-essentials": "^6.3.7",
     "@storybook/addon-viewport": "^6.3.7",
+    "@storybook/addon-postcss": "^2.0.0",
     "@storybook/html": "^6.3.7",
     "autoprefixer": "^9.8.6",
     "babel-eslint": "^10.1.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  plugins: [
+    require('postcss-flexbugs-fixes'),
+    require('autoprefixer')({
+      flexbox: 'no-2009',
+      grid: 'autoplace'
+    })
+  ]
+};


### PR DESCRIPTION
### Feature Status
- [ ]  Complete, ready for QA
- [x]  In Progress

### Description of Changes
Adding `@storybook/addon-postcss` resolves this warning:
```
DeprecationWarning: Relying on the implicit PostCSS loader is deprecated and will be removed in Storybook 7.0.
If you need PostCSS, include '@storybook/addon-postcss' in your '.storybook/main.js' file.

See https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-implicit-postcss-loader for details.
```

### How to Review
[Netifly preview](https://deploy-preview-136--think-ui-library.netlify.app/) 

Outline the steps a reviewer should take to view & test code locally.

1. `git fetch && git checkout fix/post-css-config`
2. `npm start`
3. See that warning posted above does not appear in the terminal

### Dependencies
[@storybook/addon-postcss](https://www.npmjs.com/package/@storybook/addon-postcss)


### Merge Checklist:
- [ ] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the documentation.
- [x] I have verified that no browser console errors are attributed to my changes
- [ ] I have removed any commented out code.
- [x] I have run `npm run format` and `npm run lint` and both run without errors or warnings.
- [x] `npm run build` runs without failure.
