### PR TITLE
Reconfigure Webpack to generate 1 js file

### DIFF
--- a/build/config/webpack.config.babel.js
+++ b/build/config/webpack.config.babel.js
@@ -23,5 +23,5 @@ export default {
     extensions: ['.js'],
     modules: ['node_modules', 'src']
   },
-  optimization: {...optimization, ...common.optimization}
+  optimization
 };


### PR DESCRIPTION
### Feature Status
- [x]  Complete, ready for QA
- [ ]  In Progress

### Description of Changes
Reconfigure Webpack so that `SplitChunksPlugin` does not split bundle.js into multiple files (due to [file size](https://webpack.js.org/plugins/split-chunks-plugin/#defaults) exceeding 20k)

Change is directly related to [this issue](https://github.com/thinkcompany/think-ui-library/issues/137#issuecomment-909530761)

I verified this was working (the `dist` directory is git-ignored) by checking that the `vendor.js` file is no longer generated. Also, the size of `bundle.js` is back up to what it was prior to * all this *
Once this is merged and the NPM package is published, pulling it down into the theme will be the final check to ensure this is working as expected.

#### Screenshots
![Screen Shot 2021-09-01 at 9 03 22 AM](https://user-images.githubusercontent.com/1825366/131675992-e344d9a8-814b-4fb9-bb04-4f3f1d9d2482.png)


### How to Review
Outline the steps a reviewer should take to view & test code locally.

1. `git fetch && git checkout fix/bundle-vendor-js`
2. `npm build`
3. `npm start`
3. Check dist directory: `vendor.js` should no longer exist, and the size of `bundle.js` should be 26k


### Merge Checklist:
- [x] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the documentation.
- [x] I have verified that no browser console errors are attributed to my changes
- [ ] I have removed any commented out code.
- [x] I have run `npm run format` and `npm run lint` and both run without errors or warnings.
- [x] `npm run build` runs without failure.

