### PR TITLE
SWIM-774: Shift overlay down by 1px;

### DIFF
--- a/src/components/Card/_card.scss
+++ b/src/components/Card/_card.scss
@@ -283,12 +283,13 @@
     flex-flow: column wrap;
     justify-content: center;
     min-height: 332px;
+    border-bottom-width: 0;
     background: none;
 
     &::before {
       content: '';
       position: absolute;
-      bottom: -1px;
+      bottom: 0;
       left: 0;
       display: block;
       width: 100%;


### PR DESCRIPTION
### Feature Status
- [x]  Complete, ready for QA
- [ ]  In Progress

### Description of Changes
There is linear-gradient background behind the name & photo on the Person Card, which was not covering the bottom pixel of the photo. 

Once approved, I will pull this change into the site repo.

Percy is yelling about kittens again :)

[SWIM-774](https://thinkcompany.atlassian.net/browse/SWIM-774)


#### Screenshots
This is the "before" screenshot showing the exposed pixel

![Screen Shot 2021-10-11 at 9 37 38 AM](https://user-images.githubusercontent.com/1825366/136799679-cfeafa30-c471-49ea-9e16-5560a4543aca.png)


### How to Review
Check out the [Netifly preview ](https://deploy-preview-146--think-ui-library.netlify.app/?path=/story/components-card--person-card )to see that the bottom of the Person Card is now fully covered by the overlay. 


### Merge Checklist:
- [x] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the documentation.
- [x] I have verified that no browser console errors are attributed to my changes
- [ ] I have removed any commented out code.
- [ ] I have run `npm run format` and `npm run lint` and both run without errors or warnings.
- [ ] `npm run build` runs without failure.
