### PR TITLE
SWIM-820: Fix tab focus order

### DIFF
--- a/src/components/Navigation/navigation.html
+++ b/src/components/Navigation/navigation.html
@@ -66,3 +66,10 @@
     </nav>
   </div>
 </header>
+<div class="tco-container-wrapper">
+  <div class="tco-container" style="margin-top:5em;">
+    <div class="tco-component">
+      <a href="#" class="tco-text-only-cta">Learn more</a>
+    </div>
+  </div>
+</div>

--- a/src/styles/settings/mixins/_animations.scss
+++ b/src/styles/settings/mixins/_animations.scss
@@ -4,6 +4,7 @@ $item-delay: $speed * 0.9;
 
 @mixin nav-animation {
   .tco-site-nav-wrapper {
+    visibility: hidden;
     transform: translateX(100%);
     transition: transform $speed ease-out;
   }
@@ -18,6 +19,7 @@ $item-delay: $speed * 0.9;
 
   &--open {
     .tco-site-nav-wrapper {
+      visibility: visible;
       z-index: 2;
       overflow-y: auto;
       transform: translateX(0);


### PR DESCRIPTION
### Feature Status
- [x]  Complete, ready for QA
- [ ]  In Progress

### Description of Changes
Prevent focus from going directly into the hamburger menu. Adding `visibility: visible;` and `visibility: hidden;` when the navigation opens/closes did the trick. 

Once approved, the updated assets will be imported into the site theme.

[SWIM-820](https://thinkcompany.atlassian.net/browse/SWIM-820)

#### Screenshots
![keyboard-nav](https://user-images.githubusercontent.com/1825366/139913190-fc4afa46-efa3-4b73-bfe0-766d6a1c62b7.gif)

### How to Review
Place cursor near the Think logo in this [Netifly preview](https://deploy-preview-150--think-ui-library.netlify.app/?path=/story/global-header--header), and tab through the main navigation and menu icon. Focus should land on the 'Learn More' link.

### Merge Checklist:
- [x] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the documentation.
- [x] I have verified that no browser console errors are attributed to my changes
- [ ] I have removed any commented out code.
- [x] I have run `npm run format` and `npm run lint` and both run without errors or warnings.
- [x] `npm run build` runs without failure.
