### PR TITLE
Update image paths to fix missing wpengine images

### DIFF
--- a/src/components/Bio/Bio.stories.js
+++ b/src/components/Bio/Bio.stories.js
@@ -72,7 +72,7 @@ export default {
     name: 'Abby DePrimo',
     title: 'Vice President, Design Operations',
     image:
-      'https://3vwizk2qtr8l3diwrm3r2ba0-wpengine.netdna-ssl.com/wp-content/uploads/2020/03/AbbyDePrimo_Web.jpg'
+      'https://www.thinkcompany.com/wp-content/uploads/2020/03/AbbyDePrimo_Web.jpg'
   },
   argTypes: {
     showSocial: {

--- a/src/components/CardGrid/CardGrid.stories.js
+++ b/src/components/CardGrid/CardGrid.stories.js
@@ -15,7 +15,7 @@ const summaryCard = () => {
 
 const personCard = () => {
   return `
-  <div class="tco-card tco-card--person" style="background-image: url(https://3vwizk2qtr8l3diwrm3r2ba0-wpengine.netdna-ssl.com/wp-content/uploads/2020/03/AbbyDePrimo_Web.jpg)">
+  <div class="tco-card tco-card--person" style="background-image: url(https://www.thinkcompany.com/wp-content/uploads/2020/03/AbbyDePrimo_Web.jpg)">
     <a href="#" class="tco-card-link">
       <div class="tco-card-content-container">
         <h2 class="tco-card-content-heading tco-link--dark-theme">Abby DePrimo</h2>

--- a/src/components/EventPreview/event-preview.json
+++ b/src/components/EventPreview/event-preview.json
@@ -34,7 +34,7 @@
     "featured": false,
     "location": "Kleinfeltersville, PA",
     "date": "September 30, 2020",
-    "imageSrc": "https://3vwizk2qtr8l3diwrm3r2ba0-wpengine.netdna-ssl.com/wp-content/uploads/2020/04/Landing-Page-Illo-LGM-4-Dave-Thomas.png",
+    "imageSrc": "https://www.thinkcompany.com/wp-content/uploads/2020/04/Landing-Page-Illo-LGM-4-Dave-Thomas.png",
     "excerpt": "In this webinar recording, learn from real-world examples to identify some particularly nasty biases that frequently lead users to make bad decisions.",
     "authors": ["Dave Thomas"],
     "action": { "text": "Read More" }


### PR DESCRIPTION
### Feature Status
- [X]  Complete, ready for QA
- [ ]  In Progress

### Description of Changes
We turned off our WP Engine account, and a week later some Cloudfront-powered images that had been a part of the whole WP Engine thingamajigger stopped working.  This changes the links to unbreak them!

- Jira ticket: https://thinkcompany.atlassian.net/browse/SWIM-1630

#### Screenshots
This is what it looked like when it was broken:
![image](https://user-images.githubusercontent.com/43791706/159058532-b955a296-2734-4f7a-a6da-75bfa484138c.png)


### How to Review
To see the BROKEN state, visit the live site:
https://ui.thinkcompany.dev/?path=/story/components-bio--author

To see the FIXED state, visit the Netlify-powered preview link:
https://6234ca391dd94f0009d99349--think-ui-library.netlify.app/?path=/story/components-bio--author

### Dependencies
No changes to dependencies!


### Merge Checklist:
- [X] My code follows the style guidelines of this project.
- [X] I have run `npm run format` and `npm run lint` _but there are errors in code I did not touch_
- [ ] `npm run build` runs without failure.

### GIF Description
Share a fun gif that describes this PR & how it makes you feel.
https://www.reddit.com/r/BeAmazed/comments/gs3vb0/by_this_ninja_warrior_speed_run_irl/
