### PR TITLE
SWIM-1689: No max-width option in card grid

### DIFF
--- a/src/components/CardGrid/CardGrid.stories.js
+++ b/src/components/CardGrid/CardGrid.stories.js
@@ -108,6 +108,7 @@ const alignments = ['center', 'left', 'right'];
 const sizes = ['medium', 'extra-large', 'large', 'small'];
 const ledeSizes = ['default', 'large', 'sans-small'];
 const containerSizes = ['default', 'mid', 'narrow', 'none'];
+const cardMaxWidth = ['default', 'no max width'];
 
 const Template = args => {
   const {
@@ -115,6 +116,7 @@ const Template = args => {
     columns,
     count,
     cardType,
+    cardMax,
     headingContainer,
     introHeading,
     headingSize,
@@ -154,6 +156,8 @@ const Template = args => {
 
   let containerClose = '';
 
+  let maxWidth = '';
+
   if (introHeading || lede) {
     containerOpen =
       '<div class="tco-card-grid-header tco-container--' +
@@ -162,6 +166,10 @@ const Template = args => {
       headingContainer +
       '">';
     containerClose = '</div>';
+  }
+
+  if (cardMax == 'no max width') {
+    maxWidth = 'tco-card-no-max';
   }
 
   return `
@@ -185,7 +193,7 @@ const Template = args => {
               : ''
           }
         ${containerClose}
-        <div class="tco-card-grid tco-card-grid--${columns}-column">
+        <div class="tco-card-grid tco-card-grid--${columns}-column ${maxWidth}">
           ${cardItems()}
         </div>
       </div>
@@ -202,6 +210,7 @@ export default {
     columns: 3,
     count: 6,
     cardType: cardTypes[0],
+    cardMax: cardMaxWidth[0],
     headingContainer: containerSizes[0],
     introHeading: 'Card grid section',
     headingSize: sizes[0],
@@ -224,6 +233,11 @@ export default {
     count: {
       name: ' card count',
       control: 'number'
+    },
+    cardMax: {
+      name: 'card max width',
+      control: 'inline-radio',
+      options: cardMaxWidth
     },
     columns: {
       name: 'column count',

--- a/src/components/CardGrid/_card-grid.scss
+++ b/src/components/CardGrid/_card-grid.scss
@@ -95,4 +95,10 @@
       width: 100%;
     }
   }
+
+  &.tco-card-no-max {
+    .tco-card {
+      max-width: none;
+    }
+  }
 }


### PR DESCRIPTION
### Feature Status
- [x]  Complete, ready for QA
- [ ]  In Progress

### Description of Changes
Add option to remove max-width from card in card grid component

[SWIM-1689](https://thinkcompany.atlassian.net/browse/SWIM-1689)


#### Screenshots
![card-max](https://user-images.githubusercontent.com/1825366/160882308-0f31aade-94a6-4477-a175-d34dab98b041.gif)


### How to Review
Toggle card max width option in a 2 column setting in this[ Netlify preview](https://deploy-preview-162--think-ui-library.netlify.app/?path=/story/components-card-grid--card-grid&args=columns:2)


### Merge Checklist:
- [x] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have verified that no browser console errors are attributed to my changes
- [ ] I have removed any commented out code.
- [x] I have run `npm run format` and `npm run lint` and both run without errors or warnings.
- [ ] `npm run build` runs without failure.

