### PR TITLE
refactor(button): fix weird alignment issues when font-size is larger

### DIFF
--- a/src/components/Buttons/_buttons.scss
+++ b/src/components/Buttons/_buttons.scss
@@ -185,18 +185,15 @@ $big-arrow-width: calc((21 / 18) * 1em);
       $font-size-18
     );
     border-bottom-width: 0;
-    color: $color-classic-navy;
 
     svg {
-      width: $big-arrow-width;
-      height: auto;
-      transform: translate(5px, 4px);
+      transform: scale(1.2) translateX(0);
     }
 
     &:hover,
     &:focus {
       svg {
-        transform: translate(10px, 4px);
+        transform: scale(1.2) translateX(5px);
       }
     }
 

--- a/src/styles/settings/mixins/_type.scss
+++ b/src/styles/settings/mixins/_type.scss
@@ -514,9 +514,10 @@
   }
 }
 
-$arrow-width: 19px;
-$arrow-height: 17px;
+// Ensures icons scales properly when font-size changes without complicated math
+$arrow-size: 0.9em;
 $arrow-offset: 5px;
+// 👇 Appears to be used in a deprecated component tco-card-link.
 $arrow-translate: 10px;
 
 @mixin type-link-cta(
@@ -527,7 +528,9 @@ $arrow-translate: 10px;
 ) {
   // BMac wanted to remove the underline altogether for Arrow links
   @include type-link($show-initial: false, $underline: transparent);
-  padding-right: $padding-right;
+  display: inline-flex;
+  align-items: center;
+  gap: $padding-right;
   color: $font-color;
   text-decoration: none;
   font-weight: $weight;
@@ -536,11 +539,11 @@ $arrow-translate: 10px;
   .tco-text-link-icon,
   svg {
     display: inline-block;
-    width: $arrow-width;
-    height: $arrow-height;
+    width: $arrow-size;
+    height: $arrow-size;
     fill: $fill;
     transition: transform 0.2s linear;
-    transform: translate($arrow-offset, 3px);
+    transform: translateX(0);
     transform-origin: left center;
 
     &:not(.tco-text-link-icon--alt) {
@@ -554,7 +557,7 @@ $arrow-translate: 10px;
   &:focus {
     .tco-text-link--icon,
     svg {
-      transform: translate($arrow-translate, 3px);
+      transform: translateX($arrow-offset);
     }
   }
 
@@ -563,7 +566,6 @@ $arrow-translate: 10px;
     .tco-text-link-icon,
     svg {
       fill: $color-disabled;
-      transform: translate($arrow-offset, 0px);
     }
   }
 


### PR DESCRIPTION
### Feature Status
- [x]  Complete, ready to be merged
- [ ]  Blocked
- [ ]  In Progress

### Description of Changes
Describe the reason the code is being changed, and your approach to making the changes.

- I refactored the CTA link mixin to use inline-flex and relative units to ensure the icon sits nicely with the text regardless of the font-size chosen. 

#### Screenshots

We should be able to resize CTA arrow links without the icon getting out of whack:

![Screenshot 2025-03-25 at 9 01 55 PM](https://github.com/user-attachments/assets/d0c7b9c2-cf05-4ff1-b4f1-813884eb7c9e)


### How to Review
Outline the steps a reviewer should take to view & test code locally.

1. `git fetch && git checkout <your-branch>`
2. `npm start`
3. Navigate to **Components** > **Your Component**

### Dependencies
List all NPM dependencies added or changed and explain why they were added.
If no dependencies were added or changed, this heading can be removed


### Merge Checklist:
- [ ] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have verified that no browser console errors are attributed to my changes
- [ ] I have removed any commented out code.
- [ ] I have run `npm run format` and `npm run lint` and both run without errors or warnings.
- [ ] `npm run build` runs without failure.
